### PR TITLE
Fix TestChannel30 unit test

### DIFF
--- a/common/capabilities/channel_test.go
+++ b/common/capabilities/channel_test.go
@@ -113,7 +113,7 @@ func TestChannelV30(t *testing.T) {
 	cp := NewChannelProvider(map[string]*cb.Capability{
 		ChannelV3_0: {},
 	})
-	require.Error(t, cp.Supported()) // returns error (unsupported) in current v2.x binaries
+	require.NoError(t, cp.Supported())
 	require.True(t, cp.MSPVersion() == msp.MSPv1_4_3)
 	require.True(t, cp.ConsensusTypeMigration())
 	require.True(t, cp.OrgSpecificOrdererEndpoints())


### PR DESCRIPTION
The channel HasCapability() function was changed in the last commit, but the unit test was not fixed up.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
