### PR TITLE
Add orderers (consenters) to channelconfig API

### DIFF
--- a/common/channelconfig/api.go
+++ b/common/channelconfig/api.go
@@ -70,6 +70,9 @@ type Channel interface {
 	// OrdererAddresses returns the list of valid orderer addresses to connect to to invoke Broadcast/Deliver
 	OrdererAddresses() []string
 
+	// Orderers returns the list of consenters
+	Orderers() []*cb.Consenter
+
 	// Capabilities defines the capabilities for a channel
 	Capabilities() ChannelCapabilities
 }

--- a/common/channelconfig/channel.go
+++ b/common/channelconfig/channel.go
@@ -59,6 +59,7 @@ type ChannelProtos struct {
 	HashingAlgorithm          *cb.HashingAlgorithm
 	BlockDataHashingStructure *cb.BlockDataHashingStructure
 	OrdererAddresses          *cb.OrdererAddresses
+	Orderers                  *cb.Orderers
 	Consortium                *cb.Consortium
 	Capabilities              *cb.Capabilities
 }
@@ -151,6 +152,11 @@ func (cc *ChannelConfig) BlockDataHashingStructureWidth() uint32 {
 // OrdererAddresses returns the list of valid orderer addresses to connect to to invoke Broadcast/Deliver
 func (cc *ChannelConfig) OrdererAddresses() []string {
 	return cc.protos.OrdererAddresses.Addresses
+}
+
+// Orderers returns the list of consenters
+func (cc *ChannelConfig) Orderers() []*cb.Consenter {
+	return cc.protos.Orderers.ConsenterMapping
 }
 
 // ConsortiumName returns the name of the consortium this channel was created under

--- a/orderer/common/msgprocessor/mocks/channel_config.go
+++ b/orderer/common/msgprocessor/mocks/channel_config.go
@@ -4,6 +4,7 @@ package mocks
 import (
 	"sync"
 
+	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/channelconfig"
 )
 
@@ -47,6 +48,16 @@ type ChannelConfig struct {
 	}
 	ordererAddressesReturnsOnCall map[int]struct {
 		result1 []string
+	}
+	OrderersStub        func() []*common.Consenter
+	orderersMutex       sync.RWMutex
+	orderersArgsForCall []struct {
+	}
+	orderersReturns struct {
+		result1 []*common.Consenter
+	}
+	orderersReturnsOnCall map[int]struct {
+		result1 []*common.Consenter
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -260,6 +271,58 @@ func (fake *ChannelConfig) OrdererAddressesReturnsOnCall(i int, result1 []string
 	}{result1}
 }
 
+func (fake *ChannelConfig) Orderers() []*common.Consenter {
+	fake.orderersMutex.Lock()
+	ret, specificReturn := fake.orderersReturnsOnCall[len(fake.orderersArgsForCall)]
+	fake.orderersArgsForCall = append(fake.orderersArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Orderers", []interface{}{})
+	fake.orderersMutex.Unlock()
+	if fake.OrderersStub != nil {
+		return fake.OrderersStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.orderersReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChannelConfig) OrderersCallCount() int {
+	fake.orderersMutex.RLock()
+	defer fake.orderersMutex.RUnlock()
+	return len(fake.orderersArgsForCall)
+}
+
+func (fake *ChannelConfig) OrderersCalls(stub func() []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = stub
+}
+
+func (fake *ChannelConfig) OrderersReturns(result1 []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = nil
+	fake.orderersReturns = struct {
+		result1 []*common.Consenter
+	}{result1}
+}
+
+func (fake *ChannelConfig) OrderersReturnsOnCall(i int, result1 []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = nil
+	if fake.orderersReturnsOnCall == nil {
+		fake.orderersReturnsOnCall = make(map[int]struct {
+			result1 []*common.Consenter
+		})
+	}
+	fake.orderersReturnsOnCall[i] = struct {
+		result1 []*common.Consenter
+	}{result1}
+}
+
 func (fake *ChannelConfig) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -271,6 +334,8 @@ func (fake *ChannelConfig) Invocations() map[string][][]interface{} {
 	defer fake.hashingAlgorithmMutex.RUnlock()
 	fake.ordererAddressesMutex.RLock()
 	defer fake.ordererAddressesMutex.RUnlock()
+	fake.orderersMutex.RLock()
+	defer fake.orderersMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/orderer/common/multichannel/mocks/channel_config.go
+++ b/orderer/common/multichannel/mocks/channel_config.go
@@ -4,6 +4,7 @@ package mocks
 import (
 	"sync"
 
+	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/channelconfig"
 )
 
@@ -47,6 +48,16 @@ type ChannelConfig struct {
 	}
 	ordererAddressesReturnsOnCall map[int]struct {
 		result1 []string
+	}
+	OrderersStub        func() []*common.Consenter
+	orderersMutex       sync.RWMutex
+	orderersArgsForCall []struct {
+	}
+	orderersReturns struct {
+		result1 []*common.Consenter
+	}
+	orderersReturnsOnCall map[int]struct {
+		result1 []*common.Consenter
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -260,6 +271,58 @@ func (fake *ChannelConfig) OrdererAddressesReturnsOnCall(i int, result1 []string
 	}{result1}
 }
 
+func (fake *ChannelConfig) Orderers() []*common.Consenter {
+	fake.orderersMutex.Lock()
+	ret, specificReturn := fake.orderersReturnsOnCall[len(fake.orderersArgsForCall)]
+	fake.orderersArgsForCall = append(fake.orderersArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Orderers", []interface{}{})
+	fake.orderersMutex.Unlock()
+	if fake.OrderersStub != nil {
+		return fake.OrderersStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.orderersReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChannelConfig) OrderersCallCount() int {
+	fake.orderersMutex.RLock()
+	defer fake.orderersMutex.RUnlock()
+	return len(fake.orderersArgsForCall)
+}
+
+func (fake *ChannelConfig) OrderersCalls(stub func() []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = stub
+}
+
+func (fake *ChannelConfig) OrderersReturns(result1 []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = nil
+	fake.orderersReturns = struct {
+		result1 []*common.Consenter
+	}{result1}
+}
+
+func (fake *ChannelConfig) OrderersReturnsOnCall(i int, result1 []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = nil
+	if fake.orderersReturnsOnCall == nil {
+		fake.orderersReturnsOnCall = make(map[int]struct {
+			result1 []*common.Consenter
+		})
+	}
+	fake.orderersReturnsOnCall[i] = struct {
+		result1 []*common.Consenter
+	}{result1}
+}
+
 func (fake *ChannelConfig) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -271,6 +334,8 @@ func (fake *ChannelConfig) Invocations() map[string][][]interface{} {
 	defer fake.hashingAlgorithmMutex.RUnlock()
 	fake.ordererAddressesMutex.RLock()
 	defer fake.ordererAddressesMutex.RUnlock()
+	fake.orderersMutex.RLock()
+	defer fake.orderersMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/orderer/consensus/kafka/mock/channel_config.go
+++ b/orderer/consensus/kafka/mock/channel_config.go
@@ -4,6 +4,7 @@ package mock
 import (
 	"sync"
 
+	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/common/channelconfig"
 )
 
@@ -47,6 +48,16 @@ type ChannelConfig struct {
 	}
 	ordererAddressesReturnsOnCall map[int]struct {
 		result1 []string
+	}
+	OrderersStub        func() []*common.Consenter
+	orderersMutex       sync.RWMutex
+	orderersArgsForCall []struct {
+	}
+	orderersReturns struct {
+		result1 []*common.Consenter
+	}
+	orderersReturnsOnCall map[int]struct {
+		result1 []*common.Consenter
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -260,6 +271,58 @@ func (fake *ChannelConfig) OrdererAddressesReturnsOnCall(i int, result1 []string
 	}{result1}
 }
 
+func (fake *ChannelConfig) Orderers() []*common.Consenter {
+	fake.orderersMutex.Lock()
+	ret, specificReturn := fake.orderersReturnsOnCall[len(fake.orderersArgsForCall)]
+	fake.orderersArgsForCall = append(fake.orderersArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Orderers", []interface{}{})
+	fake.orderersMutex.Unlock()
+	if fake.OrderersStub != nil {
+		return fake.OrderersStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.orderersReturns
+	return fakeReturns.result1
+}
+
+func (fake *ChannelConfig) OrderersCallCount() int {
+	fake.orderersMutex.RLock()
+	defer fake.orderersMutex.RUnlock()
+	return len(fake.orderersArgsForCall)
+}
+
+func (fake *ChannelConfig) OrderersCalls(stub func() []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = stub
+}
+
+func (fake *ChannelConfig) OrderersReturns(result1 []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = nil
+	fake.orderersReturns = struct {
+		result1 []*common.Consenter
+	}{result1}
+}
+
+func (fake *ChannelConfig) OrderersReturnsOnCall(i int, result1 []*common.Consenter) {
+	fake.orderersMutex.Lock()
+	defer fake.orderersMutex.Unlock()
+	fake.OrderersStub = nil
+	if fake.orderersReturnsOnCall == nil {
+		fake.orderersReturnsOnCall = make(map[int]struct {
+			result1 []*common.Consenter
+		})
+	}
+	fake.orderersReturnsOnCall[i] = struct {
+		result1 []*common.Consenter
+	}{result1}
+}
+
 func (fake *ChannelConfig) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -271,6 +334,8 @@ func (fake *ChannelConfig) Invocations() map[string][][]interface{} {
 	defer fake.hashingAlgorithmMutex.RUnlock()
 	fake.ordererAddressesMutex.RLock()
 	defer fake.ordererAddressesMutex.RUnlock()
+	fake.orderersMutex.RLock()
+	defer fake.orderersMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
First minimal step for adding consenters to the channel config API

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>
